### PR TITLE
Add open source contribution link to Footer component

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,10 +18,21 @@ function Footer() {
         </a>{" "}
         © {currentYear}
       </p>
+      <p className="mt-1">
+        Proyecto open source. Contribuye en{" "}
+        <a
+          href="https://github.com/mateobetancurb/colombia-taxes-calculator"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          GitHub
+        </a>
+        .
+      </p>
     </footer>
   );
 }
 
 const MemoizedFooter = memo(Footer);
-
 export { MemoizedFooter as Footer };


### PR DESCRIPTION
This pull request adds a new section to the `Footer` component to encourage open source contributions. The main change is the addition of a message and link inviting users to contribute to the project on GitHub.

Enhancement to footer content:

* [`src/components/Footer.tsx`](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04R21-L26): Added a paragraph below the copyright notice stating "Proyecto open source. Contribuye en GitHub" with a link to the project's GitHub repository.