### PR TITLE
Dev

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -174,6 +174,15 @@ function App() {
                 </p>
               </div>
               <SummaryCards computation={computation} />
+              <section>
+                <h2 className="text-2xl font-semibold">{esApp.seccionCalculadora}</h2>
+                <CalculatorTabs
+                  activeCalculatorId={activeCalculatorId}
+                  calculatorInputs={calculatorInputs}
+                  onCalculatorChange={handleCalculatorChange}
+                  onInputChange={handleInputChange}
+                />
+              </section>
               <Suspense
                 fallback={
                   <Card className="h-full">
@@ -185,16 +194,6 @@ function App() {
               >
                 <LazyIncomeDonutChart computation={computation} />
               </Suspense>
-            </section>
-
-            <section>
-              <h2 className="text-2xl font-semibold">{esApp.seccionCalculadora}</h2>
-              <CalculatorTabs
-                activeCalculatorId={activeCalculatorId}
-                calculatorInputs={calculatorInputs}
-                onCalculatorChange={handleCalculatorChange}
-                onInputChange={handleInputChange}
-              />
             </section>
 
             <section className="grid gap-6 xl:grid-cols-[1.35fr_1fr]">
@@ -233,7 +232,6 @@ function App() {
                       {formatCopCurrency(computation.socialSecurityAmount)}
                     </span>
                   </p>
-                  <p>{esApp.disclaimerContador}</p>
                 </CardContent>
               </Card>
             </section>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -175,7 +175,7 @@ function App() {
               </div>
               <SummaryCards computation={computation} />
               <section>
-                <h2 className="text-2xl font-semibold">{esApp.seccionCalculadora}</h2>
+                <h2 className="text-2xl font-semibold mb-5">{esApp.seccionCalculadora}</h2>
                 <CalculatorTabs
                   activeCalculatorId={activeCalculatorId}
                   calculatorInputs={calculatorInputs}

--- a/src/components/dashboard/SummaryCards.tsx
+++ b/src/components/dashboard/SummaryCards.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from "react";
-import { BadgeDollarSign, Landmark, PiggyBank, ShieldCheck } from "lucide-react";
+import { AlertTriangle, BadgeDollarSign, Landmark, PiggyBank, ShieldCheck } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { CalculationResult } from "@/domain/tax/calculators";
 import { app, resumen } from "@/i18n/es";
@@ -46,6 +46,15 @@ function SummaryCards({ computation }: SummaryCardsProps) {
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <Card className="sm:col-span-2 xl:col-span-4 border-amber-300 bg-amber-50 shadow-none dark:border-amber-500/50 dark:bg-amber-950/50">
+        <CardContent className="flex items-center gap-3 p-4 text-sm text-amber-950 dark:text-amber-100/95">
+          <AlertTriangle
+            className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400"
+            aria-hidden
+          />
+          <p>{app.disclaimerContador}</p>
+        </CardContent>
+      </Card>
       {cards.map((card) => (
         <Card key={card.title}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -59,11 +68,6 @@ function SummaryCards({ computation }: SummaryCardsProps) {
           </CardContent>
         </Card>
       ))}
-      <Card className="sm:col-span-2 xl:col-span-4">
-        <CardContent className="pt-4 text-sm text-slate-600 dark:text-slate-300">
-          {app.disclaimerContador}
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/src/components/dashboard/SummaryCards.tsx
+++ b/src/components/dashboard/SummaryCards.tsx
@@ -45,7 +45,7 @@ function SummaryCards({ computation }: SummaryCardsProps) {
   );
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4 mb-10">
       <Card className="sm:col-span-2 xl:col-span-4 border-amber-300 bg-amber-50 shadow-none dark:border-amber-500/50 dark:bg-amber-950/50">
         <CardContent className="flex items-center gap-3 p-4 text-sm text-amber-950 dark:text-amber-100/95">
           <AlertTriangle


### PR DESCRIPTION
This pull request refactors how the disclaimer is displayed in the dashboard and improves its visibility and styling. The disclaimer is now shown more prominently at the top of the summary cards section with an alert icon, and the duplicate disclaimer at the bottom of the results has been removed. Additionally, some minor UI adjustments were made for consistency.

**UI and Disclaimer Improvements:**

* The disclaimer (`app.disclaimerContador`) is now displayed at the top of the `SummaryCards` section inside a styled card with an `AlertTriangle` icon for better visibility and emphasis. [[1]](diffhunk://#diff-26b1c33da96616edcf2f036f64f381ee589bd6e817eb185b59368b5e5d9bfd50L2-R2) [[2]](diffhunk://#diff-26b1c33da96616edcf2f036f64f381ee589bd6e817eb185b59368b5e5d9bfd50L48-R57)
* The previous disclaimer card at the bottom of the summary cards grid was removed to avoid duplication.
* The disclaimer paragraph was also removed from the bottom of the results section in `App.tsx`.

**Layout Adjustments:**

* The calculator section was moved up in `App.tsx` to appear before the results section, improving the logical flow of the UI. [[1]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07R177-R185) [[2]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L190-L199)
* Added margin to the summary cards grid for improved spacing.